### PR TITLE
Fix subscription auth middleware import

### DIFF
--- a/Backend/routes/subscriptionRoutes.js
+++ b/Backend/routes/subscriptionRoutes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { auth } = require('../middleware/auth');
+const auth = require('../middleware/auth');
 const subscriptionController = require('../controllers/subscriptionController');
 
 // Get subscription status


### PR DESCRIPTION
## Summary
- correct subscription route import for auth middleware

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847aafcb008832d8f40886e62efa313