### PR TITLE
Fix auth user reference for subscription

### DIFF
--- a/Backend/controllers/subscriptionController.js
+++ b/Backend/controllers/subscriptionController.js
@@ -5,7 +5,7 @@ const { FRONTEND_URL } = process.env;
 // Get subscription status
 exports.getSubscriptionStatus = async (req, res) => {
   try {
-    const user = await User.findById(req.user.id);
+    const user = await User.findById(req.userId);
 
     if (!user) {
       return res.status(404).json({ message: "User not found" });
@@ -29,7 +29,7 @@ exports.getSubscriptionStatus = async (req, res) => {
 // Start free trial
 exports.startFreeTrial = async (req, res) => {
   try {
-    const user = await User.findById(req.user.id);
+    const user = await User.findById(req.userId);
 
     if (!user) {
       return res.status(404).json({ message: "User not found" });
@@ -72,7 +72,7 @@ exports.createCheckoutSession = async (req, res) => {
       return res.status(400).json({ message: "Price ID is required" });
     }
 
-    const user = await User.findById(req.user.id);
+    const user = await User.findById(req.userId);
 
     if (!user) {
       return res.status(404).json({ message: "User not found" });
@@ -123,7 +123,7 @@ exports.createCheckoutSession = async (req, res) => {
 // Create Stripe customer portal session
 exports.createPortalSession = async (req, res) => {
   try {
-    const user = await User.findById(req.user.id);
+    const user = await User.findById(req.userId);
 
     if (!user) {
       return res.status(404).json({ message: "User not found" });
@@ -149,7 +149,7 @@ exports.createPortalSession = async (req, res) => {
 // Cancel subscription
 exports.cancelSubscription = async (req, res) => {
   try {
-    const user = await User.findById(req.user.id);
+    const user = await User.findById(req.userId);
 
     if (!user) {
       return res.status(404).json({ message: "User not found" });

--- a/Backend/middleware/subscription.js
+++ b/Backend/middleware/subscription.js
@@ -3,7 +3,7 @@ const User = require("../models/user");
 // Middleware to check if user has valid subscription or trial
 exports.checkSubscription = async (req, res, next) => {
   try {
-    const user = await User.findById(req.user.id);
+    const user = await User.findById(req.userId);
 
     if (!user) {
       return res.status(404).json({ message: "User not found" });


### PR DESCRIPTION
## Summary
- use `req.userId` instead of missing `req.user.id` in subscription controller and middleware

## Testing
- `npm test` in Backend *(fails: no test specified)*
- `npm run lint` in Frontend *(fails to run ESLint: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6847ac598cc8832db6c92eff391d3093