### PR TITLE
Fix user menu overflow

### DIFF
--- a/Frontend/src/pages/Dashboard/dashboard.scss
+++ b/Frontend/src/pages/Dashboard/dashboard.scss
@@ -232,7 +232,8 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  /* Allow dropdown menus to extend beyond the main container */
+  overflow: visible;
   background: #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- ensure dropdown menus aren't clipped

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c23dfbcc832d97920953b14a37b4