### PR TITLE
Add configurable trial period

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,0 +1,11 @@
+PORT=5000
+MONGODB_URI=mongodb://localhost:27017/your_db
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRES_IN=24h
+STRIPE_SECRET_KEY=sk_test_your_stripe_secret
+STRIPE_PRICE_ID=price_123456
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
+FRONTEND_URL=http://localhost:5173
+APP_VERSION=1.0.0
+NODE_ENV=development
+TRIAL_PERIOD_DAYS=14

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -13,3 +13,4 @@ This API requires Node.js with pnpm or npm.
    ```
 
 The server includes Stripe support. Ensure `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are defined in your `.env`.
+You can customize the trial duration with `TRIAL_PERIOD_DAYS`.

--- a/Backend/controllers/subscriptionController.js
+++ b/Backend/controllers/subscriptionController.js
@@ -22,7 +22,8 @@ exports.getSubscriptionStatus = async (req, res) => {
       currentPeriodEnd: user.subscriptionEndDate,
       trialStartDate: user.trialStartDate,
       trialEndDate: user.trialEndDate,
-      hasHadTrial: user.hasHadTrial
+      hasHadTrial: user.hasHadTrial,
+      trialDays: parseInt(process.env.TRIAL_PERIOD_DAYS, 10) || 14
     });
   } catch (error) {
     console.error('Error getting subscription status:', error);
@@ -44,10 +45,15 @@ exports.startFreeTrial = async (req, res) => {
       return res.status(400).json({ message: 'You have already used your free trial' });
     }
     
-    // Set trial period (14 days)
+    // Set trial period based on body param or env var
+    const daysFromBody = parseInt(req.body.trialDays, 10);
+    const trialDays = isNaN(daysFromBody)
+      ? parseInt(process.env.TRIAL_PERIOD_DAYS, 10) || 14
+      : daysFromBody;
+
     const trialStartDate = new Date();
     const trialEndDate = new Date(trialStartDate);
-    trialEndDate.setDate(trialEndDate.getDate() + 14);
+    trialEndDate.setDate(trialEndDate.getDate() + trialDays);
     
     // Update user with trial information
     user.subscriptionStatus = 'trial';
@@ -60,7 +66,8 @@ exports.startFreeTrial = async (req, res) => {
     return res.json({
       status: 'trial',
       trialStartDate,
-      trialEndDate
+      trialEndDate,
+      trialDays
     });
   } catch (error) {
     console.error('Error starting free trial:', error);

--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,17 +1,12 @@
-# Configuration de l'API Backend
 VITE_API_URL=http://localhost:5000
-# When running `npm run dev` Vite proxies `/api` to the backend
 VITE_API_BASE_URL=/api
 
-# Configuration de l'application
 VITE_APP_NAME=CRM Frontend
 VITE_APP_VERSION=1.0.0
 
-# Configuration des URLs
 VITE_FRONTEND_URL=http://localhost:5173
 
-# Configuration pour le développement
 VITE_NODE_ENV=development
 
-# Stripe Configuration
 VITE_STRIPE_PUBLISHABLE_KEY=pk_test_your_stripe_publishable_key
+VITE_TRIAL_PERIOD_DAYS=14

--- a/Frontend/src/components/SubscriptionRequired/Index.jsx
+++ b/Frontend/src/components/SubscriptionRequired/Index.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getSubscriptionStatus, createCheckoutSession, startFreeTrial, SUBSCRIPTION_STATUS } from '../../services/subscription';
+import { getSubscriptionStatus, createCheckoutSession, startFreeTrial, SUBSCRIPTION_STATUS, DEFAULT_TRIAL_DAYS } from '../../services/subscription';
 import './SubscriptionRequired.scss';
 
 const SubscriptionRequired = () => {
@@ -32,7 +32,7 @@ const SubscriptionRequired = () => {
     setError('');
     
     try {
-      await startFreeTrial();
+      await startFreeTrial(DEFAULT_TRIAL_DAYS);
       // Refresh status after starting trial
       const status = await getSubscriptionStatus();
       setSubscriptionStatus(status);
@@ -156,7 +156,7 @@ const SubscriptionRequired = () => {
           {canStartTrial && (
             <div className="trial-card">
               <div className="trial-icon">🎁</div>
-              <h2>Essai gratuit de 14 jours</h2>
+              <h2>Essai gratuit de {DEFAULT_TRIAL_DAYS} jours</h2>
               <p>Essayez toutes les fonctionnalités sans engagement</p>
               <button 
                 className="trial-button"

--- a/Frontend/src/pages/RegisterUser/Index.jsx
+++ b/Frontend/src/pages/RegisterUser/Index.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { API_ENDPOINTS, apiRequest } from "../../config/api";
-import { startFreeTrial } from "../../services/subscription";
+import { startFreeTrial, DEFAULT_TRIAL_DAYS } from "../../services/subscription";
 import "./registerUser.scss";
 
 const RegisterUser = () => {
@@ -100,7 +100,7 @@ const RegisterUser = () => {
       localStorage.setItem("user", JSON.stringify(userData.user));
       
       // 3. Start the free trial
-      await startFreeTrial();
+      await startFreeTrial(DEFAULT_TRIAL_DAYS);
 
       console.log("✅ Inscription et période d'essai activées");
       

--- a/Frontend/src/pages/Settings/Index.jsx
+++ b/Frontend/src/pages/Settings/Index.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { API_ENDPOINTS, apiRequest } from '../../config/api';
-import { getSubscriptionStatus, createPortalSession, SUBSCRIPTION_STATUS, getTrialDaysRemaining } from '../../services/subscription';
+import { getSubscriptionStatus, createPortalSession, createCheckoutSession, startFreeTrial, SUBSCRIPTION_STATUS, getTrialDaysRemaining, DEFAULT_TRIAL_DAYS } from '../../services/subscription';
 import './settings.scss';
 
 const Settings = () => {
@@ -18,6 +18,7 @@ const Settings = () => {
   });
   const [subscription, setSubscription] = useState(null);
   const [processingSubscription, setProcessingSubscription] = useState(false);
+  const [processingCheckout, setProcessingCheckout] = useState(false);
 
   useEffect(() => {
     fetchUserData();
@@ -133,6 +134,39 @@ const Settings = () => {
     }
   };
 
+  const handleSubscribe = async () => {
+    setProcessingCheckout(true);
+    setMessage('');
+    try {
+      const priceId = 'price_1OqXYZHGJMCmVBnT8YgYbL3M';
+      const { url } = await createCheckoutSession(priceId);
+      if (url) {
+        window.location.href = url;
+      } else {
+        throw new Error('No checkout URL returned');
+      }
+    } catch (error) {
+      console.error('Error creating checkout session:', error);
+      setMessage("❌ Erreur: Impossible de créer la session de paiement");
+    } finally {
+      setProcessingCheckout(false);
+    }
+  };
+
+  const handleStartTrial = async () => {
+    setProcessingCheckout(true);
+    setMessage('');
+    try {
+      await startFreeTrial(DEFAULT_TRIAL_DAYS);
+      await fetchSubscriptionData();
+    } catch (error) {
+      console.error('Error starting free trial:', error);
+      setMessage("❌ Erreur: Impossible de démarrer l'essai gratuit");
+    } finally {
+      setProcessingCheckout(false);
+    }
+  };
+
   const exportData = async () => {
     try {
       setLoading(true);
@@ -236,8 +270,40 @@ const Settings = () => {
                 </div>
               </div>
             )}
-            
-            <button 
+
+            {subscription && subscription.trialStartDate && (
+              <div className="trial-period">
+                <div className="info-label">Période d'essai:</div>
+                <div className="period-value">
+                  {new Date(subscription.trialStartDate).toLocaleDateString('fr-FR')} - {new Date(subscription.trialEndDate).toLocaleDateString('fr-FR')}
+                </div>
+              </div>
+            )}
+
+            {subscription &&
+              subscription.status !== SUBSCRIPTION_STATUS.ACTIVE &&
+              !subscription.hasHadTrial && (
+                <button
+                  onClick={handleStartTrial}
+                  className="trial-button"
+                  disabled={processingCheckout}
+                >
+                  {processingCheckout ?
+                    'Activation...' : `Commencer l'essai gratuit (${DEFAULT_TRIAL_DAYS} jours)`}
+                </button>
+            )}
+
+            {subscription && subscription.status !== SUBSCRIPTION_STATUS.ACTIVE && (
+              <button
+                onClick={handleSubscribe}
+                className="subscribe-btn"
+                disabled={processingCheckout}
+              >
+                {processingCheckout ? 'Redirection...' : "S'abonner"}
+              </button>
+            )}
+
+            <button
               onClick={handleManageSubscription}
               className="manage-subscription-btn"
               disabled={processingSubscription}

--- a/Frontend/src/services/subscription.js
+++ b/Frontend/src/services/subscription.js
@@ -1,6 +1,10 @@
 // Subscription service to handle Stripe payments and subscription status
 import { API_ENDPOINTS, apiRequest } from "../config/api";
 
+// Default trial duration from env
+export const DEFAULT_TRIAL_DAYS =
+  parseInt(import.meta.env.VITE_TRIAL_PERIOD_DAYS, 10) || 14;
+
 // Constants
 export const SUBSCRIPTION_STATUS = {
   ACTIVE: 'active',
@@ -22,10 +26,11 @@ export const getSubscriptionStatus = async () => {
 };
 
 // Start a free trial
-export const startFreeTrial = async () => {
+export const startFreeTrial = async (trialDays = DEFAULT_TRIAL_DAYS) => {
   try {
     const response = await apiRequest(API_ENDPOINTS.SUBSCRIPTION.START_TRIAL, {
-      method: 'POST'
+      method: 'POST',
+      body: JSON.stringify({ trialDays })
     });
     return response;
   } catch (error) {


### PR DESCRIPTION
## Summary
- create `.env.example` for backend with `TRIAL_PERIOD_DAYS`
- mention trial period in backend README
- allow setting trial days via body or env in `subscriptionController`
- expose trial period to clients via API response
- add trial period env var to frontend config
- support trialDays param in subscription service and UI
- show trial dates and subscribe button in Settings
- add button in Settings to activate free trial

## Testing
- `npm test` in `Backend` *(fails: Error: no test specified)*
- `npm run lint` in `Frontend` *(fails to find eslint packages)*

------
https://chatgpt.com/codex/tasks/task_e_6847c1f9ce04832d846c3803572de4ae