### PR TITLE
Fix notifications date parsing

### DIFF
--- a/Frontend/src/components/Dashboard/Notifications/notifications.jsx
+++ b/Frontend/src/components/Dashboard/Notifications/notifications.jsx
@@ -13,8 +13,18 @@ const Notifications = () => {
   useEffect(() => {
     const stored = localStorage.getItem('notificationsData');
     if (stored) {
-      setNotifications(JSON.parse(stored));
-      setLoading(false);
+      try {
+        const parsed = JSON.parse(stored);
+        const withDates = parsed.map((n) => ({
+          ...n,
+          date: n.date ? new Date(n.date) : new Date(),
+        }));
+        setNotifications(withDates);
+        setLoading(false);
+      } catch (err) {
+        console.error('Failed to parse notifications from localStorage', err);
+        generateNotifications();
+      }
     } else {
       generateNotifications();
     }


### PR DESCRIPTION
## Summary
- handle localStorage notifications data with correct date parsing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847cc5fe3f0832d9e0df6ca8402b585