### PR TITLE
Add invoice status cycle

### DIFF
--- a/Frontend/src/components/Dashboard/Billing/billing.jsx
+++ b/Frontend/src/components/Dashboard/Billing/billing.jsx
@@ -381,6 +381,47 @@ const Billing = ({ clients = [], onRefresh }) => {
     }
   };
 
+  const getNextStatusLabel = (status) => {
+    switch (status) {
+      case 'draft':
+        return 'Passer en Attente';
+      case 'pending':
+        return 'Marquer Payée';
+      case 'paid':
+        return 'Marquer En retard';
+      case 'overdue':
+        return 'Repasser en Brouillon';
+      default:
+        return 'Changer le statut';
+    }
+  };
+
+  const handleInvoiceStatusClick = (invoiceId, currentStatus) => {
+    let newStatus;
+    switch (currentStatus) {
+      case 'draft':
+        newStatus = 'pending';
+        break;
+      case 'pending':
+        newStatus = 'paid';
+        break;
+      case 'paid':
+        newStatus = 'overdue';
+        break;
+      case 'overdue':
+        newStatus = 'draft';
+        break;
+      default:
+        newStatus = 'pending';
+    }
+
+    setInvoices(prev =>
+      prev.map(inv =>
+        inv.id === invoiceId ? { ...inv, status: newStatus } : inv
+      )
+    );
+  };
+
   const formatDate = (dateStr) => {
     if (!dateStr) return "";
     try {
@@ -589,9 +630,11 @@ const Billing = ({ clients = [], onRefresh }) => {
               <div key={invoice.id} className="invoice-card">
                 <div className="invoice-header">
                   <div className="invoice-number">{invoice.invoiceNumber}</div>
-                  <div 
-                    className="invoice-status"
+                  <div
+                    className="invoice-status clickable"
                     style={{ backgroundColor: getStatusColor(invoice.status), color: 'white' }}
+                    title={getNextStatusLabel(invoice.status)}
+                    onClick={() => handleInvoiceStatusClick(invoice.id, invoice.status)}
                   >
                     {getStatusIcon(invoice.status)} {getStatusLabel(invoice.status)}
                   </div>

--- a/Frontend/src/components/Dashboard/Billing/billing.scss
+++ b/Frontend/src/components/Dashboard/Billing/billing.scss
@@ -479,6 +479,15 @@
   gap: 0.25rem;
 }
 
+.invoice-status.clickable {
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.invoice-status.clickable:hover {
+  transform: scale(1.05);
+}
+
 .invoice-content {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- make invoice statuses interactive with color/icon/tooltip for next state
- allow cycling invoice status by clicking status badge
- style clickable invoice statuses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847d61bc454832da712d6f2cafe6631