### PR TITLE
Fix invoice preview pdf mode

### DIFF
--- a/Frontend/src/components/Dashboard/Billing/invoicePreview.jsx
+++ b/Frontend/src/components/Dashboard/Billing/invoicePreview.jsx
@@ -33,7 +33,12 @@ const InvoicePreview = ({ invoice, devisDetails = [], client = {}, onClose }) =>
     try {
       setPdfMode(true);
       await new Promise(r => setTimeout(r, 100));
-      const canvas = await html2canvas(previewRef.current, { scale: 2, useCORS: true });
+      const canvas = await html2canvas(previewRef.current, {
+        scale: 2,
+        useCORS: true,
+        allowTaint: true,
+        backgroundColor: '#ffffff'
+      });
       const imgData = canvas.toDataURL('image/png');
       const pdf = new jsPDF('p', 'mm', 'a4');
       const pdfWidth = pdf.internal.pageSize.getWidth();
@@ -50,7 +55,7 @@ const InvoicePreview = ({ invoice, devisDetails = [], client = {}, onClose }) =>
   };
 
   return (
-    <div className="invoice-preview">
+    <div className={`invoice-preview ${pdfMode ? 'pdf-mode' : ''}`}>
       <div className="preview-toolbar">
         <button onClick={handleGeneratePDF} className="toolbar-btn pdf-btn">📄 Générer PDF</button>
         <button onClick={onClose} className="toolbar-btn close-btn">✕ Fermer</button>

--- a/Frontend/src/components/Dashboard/Billing/invoicePreview.scss
+++ b/Frontend/src/components/Dashboard/Billing/invoicePreview.scss
@@ -8,6 +8,15 @@
   border: 1px solid #f1f5f9;
 }
 
+.invoice-preview.pdf-mode .preview-toolbar {
+  display: none;
+}
+
+.preview-content.pdf-mode {
+  margin: 0;
+  border: none;
+}
+
 .preview-toolbar {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- fix PDF export on invoice preview by matching Devis options
- hide toolbar when generating PDF

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847d72cd970832d9c743aab64aff39c